### PR TITLE
gemini: Pin modified camera config

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -123,7 +123,7 @@ vendor/lib/libchromatix_ov4688_zsl_video_ad5823.so
 # Camera configs
 etc/camera/imx298_liteon_chromatix.xml
 etc/camera/imx298_semco_chromatix.xml
-etc/camera/msm8996_camera.xml
+etc/camera/msm8996_camera.xml|8685c76353e614b312589e848eb45d74e1c20685
 etc/camera/ov4688_chromatix.xml
 etc/camera/ov4688_primax_chromatix.xml
 


### PR DESCRIPTION
 * Config modified to set the correct mount angle for front camera,
   which is 270, as seen on stock camera configs from natrium or capricorn.
   That fixes the wrongly rotated front camera when camera HAL3 is enabled.

Change-Id: I05d3e13ee74de57922a34ee7656060719c05a6c2